### PR TITLE
Adding the NZ GitHub User Group

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Of course! We'd love you to! See the [contribution guide](contributing.md) for h
 | [Perth Microsoft Data and Analytics User Group](https://www.meetup.com/en-AU/Perth-Microsoft-Data-And-Analytics-User-Group/) | AU/WA | Intermittent | Microsoft |
 | [Perth Modern Excel and Power BI Meetup ](https://www.meetup.com/en-AU/Perth-Modern-Excel-Power-BI-User-Group/) | AU/WA | Monthly | Virtual |
 | [Aotearoa Azure Meetup](https://www.meetup.com/Auckland-Azure-Usergroup/) | NZ/AKL | 3rd Thursday of every month | Microsoft House (Level 5/22 Viaduct Harbour Ave, Auckland, 1010) |
+| [Aotearoa NZ GitHub User Group](https://www.meetup.com/aotearoa-nz-github-user-group/) | NZ/AKL | Every 2-3 months | Microsoft House (Level 5/22 Viaduct Harbour Ave, Auckland, 1010) |
 | [Auckland Microsoft 365 User Group](https://www.meetup.com/Auckland-Microsoft-365-User-Group/) | NZ/AKL | Monthly | Microsoft House (Level 5/22 Viaduct Harbour Ave, Auckland, 1010) |
 | [Auckland Power Platform User Group](https://powerusers.microsoft.com/t5/Auckland-Power-Platform-User/gh-p/pp_auckland_usergroup) | NZ/AKL | Monthly | Virtual |
 | [Microsoft Modern Workplace User Group](https://www.meetup.com/New-Zealand-UC-User-Group/) | NZ/AKL | Last Thursday of every 2 months @ 3PM | Online and Microsoft Auckland|


### PR DESCRIPTION
This pull request adds a new user group to the list of meetups in the `readme.md` file.

Meetup additions:

* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R67): Added the "Aotearoa NZ GitHub User Group" to the list of meetups, specifying that it meets every 2-3 months at Microsoft House in Auckland, NZ.